### PR TITLE
prototype for logmetrics-generator

### DIFF
--- a/cmd/logmetrics-generator/config.json
+++ b/cmd/logmetrics-generator/config.json
@@ -1,0 +1,5 @@
+{
+    "name": "levelDebug",
+    "type": "counter",
+    "logqlExpr": "{app=\"dev\"} |= \"debug\""
+}

--- a/cmd/logmetrics-generator/main.go
+++ b/cmd/logmetrics-generator/main.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/grafana/loki/cmd/logmetrics-generator/metrics"
+	"github.com/grafana/loki/pkg/logql/syntax"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type FileState struct {
+	Path   string
+	Offset int64
+}
+
+type Configuration struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	LogqlExpr string `json:"logqlExpr"`
+}
+
+var config Configuration
+
+func main() {
+
+	// Get the configuration
+	config = getConfig()
+
+	fmt.Println(config.LogqlExpr)
+	metrics.GetMonitor().AddMetric(&metrics.Metric{
+		Type:        metrics.Counter,
+		Name:        config.Name,
+		Description: "Number of debug logs",
+		Labels:      []string{"provider"},
+	})
+
+	go func() {
+
+		http.Handle("/metrics", promhttp.Handler())
+		log.Fatal(http.ListenAndServe(":8080", nil))
+
+	}()
+
+	folder := "./cmd/logmetrics-generator/tmp-logs"
+	existingFiles, err := getExistingFiles(folder)
+	if err != nil {
+		log.Fatal("Error getting existing files:", err)
+	}
+
+	fileStates := make(map[string]*FileState)
+
+	for _, file := range existingFiles {
+		fileStates[file] = &FileState{
+			Path:   file,
+			Offset: 0,
+		}
+
+		go tailFile(fileStates[file])
+
+	}
+
+	// to keep the goroutine running
+	select {}
+}
+
+func getConfig() Configuration {
+
+	// Open the JSON file
+	file, err := os.Open("./cmd/logmetrics-generator/config.json")
+	if err != nil {
+		log.Fatal("Error opening file:", err)
+	}
+	defer file.Close()
+
+	// Read the file contents
+	fileData, err := ioutil.ReadAll(file)
+	if err != nil {
+		log.Fatal("Error reading file:", err)
+	}
+
+	// Parse the JSON
+	var config Configuration
+	err = json.Unmarshal(fileData, &config)
+	if err != nil {
+		log.Fatal("Error parsing JSON:", err)
+	}
+
+	return config
+}
+
+func getExistingFiles(folder string) ([]string, error) {
+	files := make([]string, 0)
+
+	err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	return files, err
+}
+
+func tailFile(fileState *FileState) {
+	fmt.Println("Tailing file:", fileState.Path)
+
+	f, err := os.Open(fileState.Path)
+	if err != nil {
+		log.Println("Error opening file:", err)
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	if err := scanner.Err(); err != nil {
+		log.Println("Error scanning file:", err)
+		return
+	}
+
+	for {
+		stat, err := f.Stat()
+		if err != nil {
+			log.Println("Error getting file stat:", err)
+			return
+		}
+
+		if stat.Size() < fileState.Offset {
+			// File has been truncated or rotated, reset the offset to the beginning
+			fileState.Offset = 0
+		}
+
+		_, err = f.Seek(fileState.Offset, io.SeekStart)
+		if err != nil {
+			log.Println("Error seeking file:", err)
+			return
+		}
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := scanner.Text()
+			fmt.Println("New line:", line)
+
+			exprQuery := config.LogqlExpr
+			expr, err := syntax.ParseLogSelector(exprQuery, true)
+
+			if err != nil {
+				fmt.Println("Error:", err)
+				return
+			}
+
+			p, err := expr.Pipeline()
+			if err != nil {
+				fmt.Println("Error:", err)
+				return
+			}
+
+			sp := p.ForStream(labels.EmptyLabels())
+			_, _, matches := sp.ProcessString(0, line)
+			if !matches {
+				fmt.Println("No matches")
+				continue
+			}
+
+			metrics.GetMonitor().GetMetric(config.Name).Inc([]string{"logmetrics-generator"})
+
+			fmt.Println("Matches:", matches)
+		}
+
+		if err := scanner.Err(); err != nil {
+			log.Println("Error scanning file:", err)
+			return
+		}
+
+		fileState.Offset = stat.Size()
+
+		time.Sleep(time.Second) // Adjust the interval as per your needs
+	}
+}

--- a/cmd/logmetrics-generator/metrics/metric.go
+++ b/cmd/logmetrics-generator/metrics/metric.go
@@ -1,0 +1,145 @@
+package metrics
+
+import (
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type MetricType int
+
+const (
+	None MetricType = iota
+	Counter
+	Gauge
+	Histogram
+	Summary
+)
+
+var promTypeHandler = map[MetricType]func(metric *Metric) error{
+	Counter:   counterHandler,
+	Gauge:     gaugeHandler,
+	Histogram: histogramHandler,
+	Summary:   summaryHandler,
+}
+
+// Metric defines a metric object
+type Metric struct {
+	Type        MetricType
+	Name        string
+	Description string
+	Labels      []string
+	Buckets     []float64
+	Objectives  map[float64]float64
+
+	vec prometheus.Collector
+}
+
+// Set data for Gauge type Metric.
+func (m *Metric) Set(labelValues []string, value float64) error {
+	if m.Type == None {
+		return errors.Errorf("metric '%s' not existed.", m.Name)
+	}
+
+	if m.Type != Gauge {
+		return errors.Errorf("metric '%s' not Gauge type", m.Name)
+	}
+	m.vec.(*prometheus.GaugeVec).WithLabelValues(labelValues...).Set(value)
+	return nil
+}
+
+// Inc increases value for Counter/Gauge type metric, increments
+// the counter by 1
+func (m *Metric) Inc(labelValues []string) error {
+	if m.Type == None {
+		return errors.Errorf("metric '%s' not existed.", m.Name)
+	}
+
+	if m.Type != Gauge && m.Type != Counter {
+		return errors.Errorf("metric '%s' not Gauge or Counter type", m.Name)
+	}
+	switch m.Type {
+	case Counter:
+		m.vec.(*prometheus.CounterVec).WithLabelValues(labelValues...).Inc()
+	case Gauge:
+		m.vec.(*prometheus.GaugeVec).WithLabelValues(labelValues...).Inc()
+	}
+	return nil
+}
+
+// Add adds the given value to the Metric object. Only
+// for Counter/Gauge type metric.
+func (m *Metric) Add(labelValues []string, value float64) error {
+	if m.Type == None {
+		return errors.Errorf("metric '%s' not existed.", m.Name)
+	}
+
+	if m.Type != Gauge && m.Type != Counter {
+		return errors.Errorf("metric '%s' not Gauge or Counter type", m.Name)
+	}
+	switch m.Type {
+	case Counter:
+		if value < 0 {
+			return errors.Errorf("metric '%s' value cannot be negative", m.Name)
+		}
+		m.vec.(*prometheus.CounterVec).WithLabelValues(labelValues...).Add(value)
+	case Gauge:
+		m.vec.(*prometheus.GaugeVec).WithLabelValues(labelValues...).Add(value)
+	}
+	return nil
+}
+
+// Observe is used by Histogram and Summary type metric to
+// add observations.
+func (m *Metric) Observe(labelValues []string, value float64) error {
+	if m.Type == 0 {
+		return errors.Errorf("metric '%s' not existed.", m.Name)
+	}
+	if m.Type != Histogram && m.Type != Summary {
+		return errors.Errorf("metric '%s' not Histogram or Summary type", m.Name)
+	}
+	switch m.Type {
+	case Histogram:
+		m.vec.(*prometheus.HistogramVec).WithLabelValues(labelValues...).Observe(value)
+	case Summary:
+		m.vec.(*prometheus.SummaryVec).WithLabelValues(labelValues...).Observe(value)
+	}
+	return nil
+}
+
+func counterHandler(metric *Metric) error {
+	metric.vec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: metric.Name, Help: metric.Description},
+		metric.Labels,
+	)
+	return nil
+}
+
+func gaugeHandler(metric *Metric) error {
+	metric.vec = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: metric.Name, Help: metric.Description},
+		metric.Labels,
+	)
+	return nil
+}
+
+func histogramHandler(metric *Metric) error {
+	if len(metric.Buckets) == 0 {
+		return errors.Errorf("metric '%s' is histogram type, cannot lose bucket param.", metric.Name)
+	}
+	metric.vec = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{Name: metric.Name, Help: metric.Description, Buckets: metric.Buckets},
+		metric.Labels,
+	)
+	return nil
+}
+
+func summaryHandler(metric *Metric) error {
+	if len(metric.Objectives) == 0 {
+		return errors.Errorf("metric '%s' is summary type, cannot lose objectives param.", metric.Name)
+	}
+	metric.vec = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{Name: metric.Name, Help: metric.Description, Objectives: metric.Objectives},
+		metric.Labels,
+	)
+	return nil
+}

--- a/cmd/logmetrics-generator/metrics/monitor.go
+++ b/cmd/logmetrics-generator/metrics/monitor.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Monitor is an object that uses to set server monitor.
+type Monitor struct {
+	metrics map[string]*Metric
+}
+
+var monitor *Monitor
+
+// GetMonitor used to get global Monitor object,
+// this function returns a singleton object.
+func GetMonitor() *Monitor {
+	if monitor == nil {
+		monitor = &Monitor{
+			metrics: make(map[string]*Metric),
+		}
+	}
+	return monitor
+}
+
+// GetMetric used to get metric object by metric_name.
+func (m *Monitor) GetMetric(name string) *Metric {
+	if metric, ok := m.metrics[name]; ok {
+		return metric
+	}
+	return &Metric{}
+}
+
+// AddMetric add metric object to Monitor.
+func (m *Monitor) AddMetric(metric *Metric) error {
+	if _, ok := m.metrics[metric.Name]; ok {
+		return errors.Errorf("metric '%s' is existed", metric.Name)
+	}
+
+	if metric.Name == "" {
+		return errors.Errorf("metric name cannot be empty.")
+	}
+	if f, ok := promTypeHandler[metric.Type]; ok {
+		if err := f(metric); err == nil {
+			prometheus.MustRegister(metric.vec)
+			m.metrics[metric.Name] = metric
+			return nil
+		}
+	}
+	return errors.Errorf("metric type '%d' not existed.", metric.Type)
+}

--- a/cmd/logmetrics-generator/tmp-logs/1.log
+++ b/cmd/logmetrics-generator/tmp-logs/1.log
@@ -1,0 +1,4 @@
+level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/first_line (200) 1.5s
+level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/second_last_time (200) 1.5s
+level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/last_line (200) 1.5s
+


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new tool logmetrics-generator. (currently a prototype)

**Problem Statements:**
- We are currently experiencing a significant volume of discarded logs in the Loki system, leading to adverse effects tech. metrics.
- Querying large volumes of data with Loki is resulting in significant delays and, in some cases, resulting in errors stating that sampling cannot be performed on more than a certain number of lines.

**Proposed Solution:**
 To address these issues, a service can be implemented that can parse log statements by tailing the log file. This service will extract relevant information from the logs in real-time and convert it into metrics. These metrics can then be scraped by Prometheus. To ensure ease of use and seamless migration of LogQL queries, the configuration of the proposed service will be designed with simplicity in mind.
 
**Protype Setup Commands:**
```bash
git clone https://github.com/parthw/loki.git
cd loki
git checkout logmetrics-generator
go mod tidy
go run cmd/logmetrics-generator/main.go
```
To access the metrics endpoint, please visit: localhost:8080/metrics
Check for metric - **levelDebug**